### PR TITLE
sheep: fix false error logging message on updating epoch

### DIFF
--- a/sheep/group.c
+++ b/sheep/group.c
@@ -385,7 +385,7 @@ int epoch_log_read_remote(uint32_t epoch, struct sd_node *nodes, int len,
 
 		*nr_nodes = nodes_len / sizeof(struct sd_node);
 		/* epoch file is missing in local node, try to create one */
-		update_epoch_log(epoch, nodes, *nr_nodes);
+		update_epoch_log(epoch, nodes, *nr_nodes, false);
 		return SD_RES_SUCCESS;
 	}
 
@@ -552,7 +552,7 @@ int inc_and_log_epoch(void)
 	uatomic_inc(&sys->cinfo.epoch);
 
 	return update_epoch_log(sys->cinfo.epoch, sys->cinfo.nodes,
-				sys->cinfo.nr_nodes);
+				sys->cinfo.nr_nodes, true);
 }
 
 static struct vnode_info *alloc_old_vnode_info(void)

--- a/sheep/sheep_priv.h
+++ b/sheep/sheep_priv.h
@@ -387,7 +387,8 @@ void queue_cluster_request(struct request *req);
 int prepare_iocb(uint64_t oid, const struct siocb *iocb, bool create);
 int err_to_sderr(const char *path, uint64_t oid, int err);
 
-int update_epoch_log(uint32_t epoch, struct sd_node *nodes, size_t nr_nodes);
+int update_epoch_log(uint32_t epoch, struct sd_node *nodes,
+		      size_t nr_nodes, bool force_create);
 int inc_and_log_epoch(void);
 
 extern char *config_path;

--- a/sheep/store/common.c
+++ b/sheep/store/common.c
@@ -81,7 +81,8 @@ int err_to_sderr(const char *path, uint64_t oid, int err)
 	}
 }
 
-int update_epoch_log(uint32_t epoch, struct sd_node *nodes, size_t nr_nodes)
+int update_epoch_log(uint32_t epoch, struct sd_node *nodes,
+		      size_t nr_nodes, bool force_create)
 {
 	int ret, len, nodes_len;
 	time_t t;
@@ -108,7 +109,7 @@ int update_epoch_log(uint32_t epoch, struct sd_node *nodes, size_t nr_nodes)
 
 	snprintf(path, sizeof(path), "%s%08u", epoch_path, epoch);
 
-	ret = atomic_create_and_write(path, buf, len, true);
+	ret = atomic_create_and_write(path, buf, len, force_create);
 
 	free(buf);
 	return ret;


### PR DESCRIPTION
multi recover threads might call update_epoch_log to create local
epoch log from remote at the same time. update_epoch_log
always call atomic_create_and_write with force_create = true
and may fail to rename with ENOENT.

To fix this, A new argument is introduced to update_epoch_log.

Signed-off-by: niko tongfw@gmail.com
