### PR TITLE
sheep: fix non-zero memory panic caused by glibc calloc bug

### DIFF
--- a/sheep/recovery.c
+++ b/sheep/recovery.c
@@ -1109,6 +1109,7 @@ static void queue_recovery_work(struct recovery_info *rinfo)
 	case RW_RECOVER_OBJ:
 		row = xzalloc(sizeof(*row));
 		row->oid = rinfo->oids[rinfo->next];
+		row->stop = false;
 
 		rw = &row->base;
 		rw->work.fn = recover_object_work;

--- a/sheep/request.c
+++ b/sheep/request.c
@@ -656,6 +656,11 @@ static struct request *alloc_request(struct client_info *ci,
 		}
 	}
 
+	INIT_LIST_NODE(&req->pending_list);
+	INIT_LIST_NODE(&req->request_list);
+	req->local = false;
+	req->local_req_efd = 0;
+
 	req->ci = ci;
 	refcount_inc(&ci->refcnt);
 


### PR DESCRIPTION
crash log in centos 7.2 environment:

Feb 23 09:49:11  EMERG [io] eventfd_xwrite(319) PANIC:
    eventfd_write() failed, Bad file descriptor
Feb 23 09:49:11  EMERG [io] crash_handler(288) sheep
    exits unexpectedly (Aborted), si pid 99206, uid ,
    errno 0, code -6

req->local is not explicitly initialized and may panic
in put_request() in case calloc returned non-zero memory.
check https://bugzilla.redhat.com/show_bug.cgi?id=1256285

If glibc is updated to the latest version(>=2.17-106.2),
this patch is unnecessary, just in case.

Signed-off-by: niko tongfw@gmail.com
